### PR TITLE
Adjust portrait image sizing in graduation post

### DIFF
--- a/_posts/2021-03-22-#2-从语言学校毕业了.md
+++ b/_posts/2021-03-22-#2-从语言学校毕业了.md
@@ -9,15 +9,9 @@ catalog: false
 tags:
     - 2021
 ---
-<style>
-img{
-    width: 60%;
-}
-</style>
-
 马上就从语言学校毕业了。用自己那不成熟的日语写了一篇小作文，记在大家的毕业纪念册里，同时也怀念一下这一年半光阴飞逝的日子。
 
-![サムの卒業式](https://raw.githubusercontent.com/krydenz/krydenz.github.io/master/img/blog/2021-03-22-01.jpg#pic_center)
+<img class="post-image post-image--medium" src="/img/blog/2021-03-22-01.jpg" alt="サムの卒業式">
 <span style="color:gray;text-align:center;display:block;"><i>サムの卒業式</i></span>
 
 まもなくサムを卒業します。もう一年半が過ぎました。とても早く感じます。
@@ -32,19 +26,19 @@ img{
 
 将来、私は優秀なエンジニアになりたいです。これからも、先進的な科学の知識を身につけて、社会の発展と人々の幸せの為に挑戦に毎日頑張ります。
 
-![毕业证书](https://raw.githubusercontent.com/krydenz/krydenz.github.io/master/img/blog/2021-03-22-02.jpg#pic_center)
+<img class="post-image post-image--wide" src="/img/blog/2021-03-22-02.jpg" alt="毕业证书">
 <span style="color:gray;text-align:center;display:block;"><i>毕业证书</i></span>
 
 看着毕业证书和刚来学校第一天入学式里与老师同学们的合影，我感慨万千。这一年，一切都变化太大了。。。在喧嚣和迷乱的世界中前行，看不清道路的方向，仿佛一切都失控了。但最后我总是那个幸运儿，总能得到一个好的结果。无论是修士入学考试还是日语N1测试，自己都是几乎踩着分数线合格的，虽然内心无比慌张，好在最后一切遂愿。还是要努力充实自己，只有实力在身才能培育出一个强大的内心。
 
 自己还是很感谢语言学校这一年半的生活的。。。虽然感觉日语的学习确实荒废了不少（汗）。回顾一下自己的语校学习生活，一上来最初的两个月可能是最认真的，几乎天天上午来学校备考N2。考完试就开始准备合唱大会的活动。春天到夏天是备考研究生的阶段，加上疫情几乎没怎么能好好学日语。在不断的备考和面试之中奔波，整个夏天过得非常的快。秋冬边玩边学，N1居然也考过了——大家都说因为疫情考试的难度降低了半级，我自己也是如此觉得的。
 
-![さらば新宿](https://raw.githubusercontent.com/krydenz/krydenz.github.io/master/img/blog/2021-03-22-03.jpg#pic_center)
+<img class="post-image post-image--wide" src="/img/blog/2021-03-22-03.jpg" alt="さらば新宿">
 <span style="color:gray;text-align:center;display:block;"><i>さらば新宿</i></span>
 
 感觉疫情并没有对繁华的新大久保造成很大的影响，虽然少了许多游客，但站前的行人依旧熙熙攘攘。一年半的时间里每天都从这里下车，看着这个小站台逐渐变成了一个商业综合体。新大久保总是给我种怀旧的感觉，大概是因为我的中学时期是韩流的鼎盛时期，大概是也因为它和沈阳西塔的风格很像。不那么精致的消费主义，鳞次栉比的奶茶店和韩流小商店，培训班和成群结队的学生，泡菜、烧烤和街边回荡的kpop音乐，总是把我带回到过去的那个年代。
 
-![阳台风景](https://raw.githubusercontent.com/krydenz/krydenz.github.io/master/img/blog/2021-03-22-04.jpg#pic_center)
+<img class="post-image post-image--medium" src="/img/blog/2021-03-22-04.jpg" alt="阳台风景">
 <span style="color:gray;text-align:center;display:block;"><i>阳台风景</i></span>
 
 在同学的阳台，晴朗的夜里远远地可以望见晴空塔。我们最后一次悠闲地在这里交谈，回忆起刚来日本时的日子。转眼间春天也要过去了。说实话，当要离开这个破旧的宿舍楼的时候，自己居然生出了一丝不舍——或许是习惯的力量，或许是对过去的留恋，或许是对未知的不安——不过正是这种把我夹在中间的复杂感情：一面是种充满怀旧的理想主义情绪，另一面又是种审判即将到来的紧张感——驱使我继续前行。无论乐意与否，我都必须离开这里，继续前行。


### PR DESCRIPTION
### Motivation
- Use `post-image--medium` for portrait photos and `post-image--wide` for landscape photos to match the site’s shared image sizing conventions.
- Make image sizing consistent and responsive by relying on the theme classes instead of inline styles.
- Keep all images referenced via local paths under `/img/blog/...` for portability.

### Description
- Updated `_posts/2021-03-22-#2-从语言学校毕业了.md` to change `post-image--wide` to `post-image--medium` on `2021-03-22-01.jpg` and `2021-03-22-04.jpg`.
- Left `post-image--wide` for landscape images `2021-03-22-02.jpg` and `2021-03-22-03.jpg`.
- Preserved existing caption `<span>` elements and `alt` text for each image.

### Testing
- No automated tests were run because this is a content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696644a32a648322a3935ebbdf37ab80)