### PR TITLE
Standardize image markup in `怀念wowaka` post

### DIFF
--- a/_posts/2021-09-16-#3-怀念wowaka.md
+++ b/_posts/2021-09-16-#3-怀念wowaka.md
@@ -10,14 +10,9 @@ tags:
     - 2021
 ---
 
-<style>
-img{
-    width: 60%;
-}
-</style>
 如果当初没有在机缘巧合之下看过39演唱会的切片，我估计连整个VOCALOID圈都不会接触。世末舞厅是甩葱歌之后我接触到的第一支V圈的曲子。 高考前偷跑去网吧打游戏，为什么会有刷到VOCALOID的缘分，至今还是个谜。。。虽然当年土豆网视频模糊的好像是从门镜里拍摄的一样，音质也渣到刺耳的程度，但是我还是一下子就被miku和luka的歌舞吸引住了。后来我才知道，用软件也能模仿人声去唱歌，有那么多作曲家在创作各种好听的曲子，miku的形象则又好像给声音注入了灵魂般充满了魔力。 那时候的创作者们也都充满了天马行空的想象，饱怀激情地在这种新的艺术创作方式上倾注自己的才华。
 
-![wowaka](https://raw.githubusercontent.com/krydenz/krydenz.github.io/master/img/blog/2021-09-16-01.jpg#pic_center)
+<img class="post-image post-image--medium" src="/img/blog/2021-09-16-01.jpg" alt="wowaka">
 <span style="color:gray;text-align:center;display:block;"><i>wowaka</i></span>
 
 wowaka的曲风有种独特的中毒性，如海妖般让人沉醉。充满“疾走感”的电音旋律可能恰好在一定程度上扬长避短，克服了早期技术上的短板；歌词又描绘了一个光怪陆离的奇妙情感世界。令人惊异的电吉他旋律则成为了他曲风最大的标志物，听过一次就令人难以忘记。 继doriko和八爷后，wowaka成为第三个在nico投稿10曲以上同时全部作品进入殿堂的up主，这也是早期那个百花齐放年代V圈观众对他实力的肯定吧 。
@@ -30,7 +25,7 @@ wowaka的曲风有种独特的中毒性，如海妖般让人沉醉。充满“�
 
 19年，当我终于有机会从生活中喘一口气，计划着有机会去日本线下支持一波wowaka ，得到的居然是他离开人世的消息！那天早晨我像往常一样随便刷刷推看看自己关注的艺人什么的，迎面而来的居然是八爷发的悼念wowaka的文章，明明几天前还在慨叹“令和”的美丽啊。。。四月是花开的季节，在鲜花盛开的时候你却沉沉睡去了。。。  当时我是非常的震惊，也才发现居然已经过去那么久的时间啦。。。我仿佛又回到了那些中学时代的夜晚，一个人在屋子里，一边在为那些幼稚的东西发愁，一边又遨游在光怪陆离的世界。
 
-![keep moving forward](https://raw.githubusercontent.com/krydenz/krydenz.github.io/master/img/blog/2021-09-16-02.jpg#pic_center)
+<img class="post-image post-image--wide" src="/img/blog/2021-09-16-02.jpg" alt="keep moving forward">
 <span style="color:gray;text-align:center;display:block;"><i>keep moving forward -- 致偶然发现的许许多多小美好</i></span>
 
 今天晚上听歌偶然听见了这首尼尔·杨的Expecting to Fly，不知道为什么突然让我想起了wowaka。思维如同潮涌一般，回忆起许多过去的事情。回想起来，我从未叫过他"现实逃避p"。在那些阴暗的日子里，我们曾一起度过；今天我也非常的伤感，但是你却又一次给了我勇气。只有不逃避，去直面这个惨淡的现实，才是真正的勇者吧。一次次的跌倒，又一次次爬起来，靠的就是这些微小的光亮吧；我写下这篇文章，只是想说一声"谢谢“。  


### PR DESCRIPTION
### Motivation
- Align `_posts/2021-09-16-#3-怀念wowaka.md` image markup with the site's standard post image format (as used in other posts) and remove inline styling for consistent presentation.

### Description
- Remove the inline `<style>` block and replace raw GitHub-hosted markdown image links with `<img>` tags using `post-image` classes in `_posts/2021-09-16-#3-怀念wowaka.md`, preserving captions and alt text.

### Testing
- No automated tests were run because this is a content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678d45ec188322906e34b49721b54d)