### PR TITLE
Remove sidebar search placeholder text

### DIFF
--- a/_includes/sidebar-search.html
+++ b/_includes/sidebar-search.html
@@ -5,7 +5,7 @@
         <input
             type="search"
             class="sidebar-search-field"
-            placeholder="按标题 / 标签 / 年份搜索"
+            placeholder=""
             aria-label="按标题、标签或年份搜索文章"
             data-blog-search-input
         >


### PR DESCRIPTION
### Motivation
- Remove the default hint text inside the sidebar search input so the field no longer shows a redundant placeholder.

### Description
- Clear the search input `placeholder` in `_includes/sidebar-search.html` by setting it to `placeholder=""` (one-line change).

### Testing
- Started a local preview with `python -m http.server` which served the site, and attempted a visual check with `Playwright` to capture a screenshot but the headless Chromium process crashed (SIGSEGV), so the browser-based screenshot/test failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697001e98dec8322afe7e6e5ed2967bc)